### PR TITLE
prevent error if no ahk version is selected

### DIFF
--- a/launcher.ahk
+++ b/launcher.ahk
@@ -342,7 +342,9 @@ class VersionSelectGui extends AutoHotkeyUxGui {
     }
     
     Confirm(*) {
-        this.selection := this.files[this['List'].GetNext()]
+        if !(i := this['List'].GetNext())
+            return
+        this.selection := this.files[i]
         this.Hide()
     }
     


### PR DESCRIPTION
When the launcher presents a list of versions to choose from and you press Enter without selecting a version first, the error "Error: Invalid index." is displayed. Fix: Do nothing when nothing is selected and Enter is pressed.