### PR TITLE
Add #Requires suggestion to TryToInstallVersion dialog

### DIFF
--- a/launcher.ahk
+++ b/launcher.ahk
@@ -152,8 +152,8 @@ IdentifyAndLaunch(ScriptPath, args, switches) {
 TryToInstallVersion(v, r, ScriptPath, require, prefer) {
     ; This is currently designed only for downloading the latest bug-fix of a given minor version.
     SplitPath ScriptPath, &name
-    m := ' script you are trying to run requires AutoHotkey v' v ', which is not installed.`n`nScript:`t' name
-    m := !(r && r != '#Requires') ? 'The' m : 'It looks like the' m '`nRule:`t' r
+    m := ' script you are trying to run requires AutoHotkey v' v ', which is not installed.'
+    m := !(r && r != '#Requires') ? 'The' m '`n`nScript:`t' name : 'It looks like the' m '`nIf the version has been misidentified, please add a #Requires directive to your script file.`n`nScript:`t' name '`nRule:`t' r
     if downloadable := IsNumber(v) || VerCompare(v, '1.1.24.02') >= 0 {
         ; Get current version compatible with v.
         bv := v = 1 ? '1.1' : IsInteger(v) ? v '.0' : RegExReplace(v, '^\d+(?:\.\d+)?\b\K.*')


### PR DESCRIPTION
When the dialog appears that says

> It looks like the script you are trying to run requires AutoHotkey vX, which is not installed.

add an additional line to the dialog that says

> If the version has been misidentified, please add a #Requires directive to your script file.

By this hint a user who does not mean to use v1, but has tripped an auto-detection by accident, can be guided towards continuing to debug in v2 rather than being blocked from seeing the more descriptive errors that will be produced by the v2 parser.