### PR TITLE
Suppress PCRE errors in identify.ahk

### DIFF
--- a/inc/identify.ahk
+++ b/inc/identify.ahk
@@ -3,15 +3,17 @@
 IdentifyBySyntax(code) {
     static identify_regex := get_identify_regex()
     p := 1, count_1 := count_2 := 0, version := marks := ''
-    while (p := RegExMatch(code, identify_regex, &m, p)) {
-        p += m.Len()
-        if SubStr(m.mark,1,1) = 'v' {
-            switch SubStr(m.mark,2,1) {   
-            case '1': count_1++
-            case '2': count_2++
+    try {
+        while (p := RegExMatch(code, identify_regex, &m, p)) {
+            p += m.Len()
+            if SubStr(m.mark,1,1) = 'v' {
+                switch SubStr(m.mark,2,1) {   
+                case '1': count_1++
+                case '2': count_2++
+                }
+                if !InStr(marks, m.mark)
+                    marks .= m.mark ' '
             }
-            if !InStr(marks, m.mark)
-                marks .= m.mark ' '
         }
     }
     if !(count_1 || count_2)


### PR DESCRIPTION
I imagine it is difficult, or even impossible to create a regular expression of this complexity that will never have some kind of stack overflow or backtracking issue. Even if a specific backtracking issue is resolved, it's very likely another remains undiscovered, or is introduced somehow by the change that fixed the original backtracking issue. 

Rather than allow a PCRE exception to cause a generic error dialog, I suggest that it is simply suppressed and the identification routine continues as if no detection occurred. This should allow the user to click and choose the appropriate version to continue with, rather than having the code fail loudly with no clear way to resolve the issue.

This change would close out forum bug reports such as https://www.autohotkey.com/boards/viewtopic.php?f=14&t=124397, https://www.autohotkey.com/boards/viewtopic.php?f=14&t=125088, and prevent further forum posts under "Ask for Help" and Discord help threads about PCRE errors when the expression fails catastrophically against some non-trivial input or unlucky trivial input.