### PR TITLE
Update links in README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,11 +4,11 @@ Installer and other scripts packaged with AutoHotkey v2, aimed at improving the 
 
 Most of the content of this repository ends up in the UX subdirectory of an AutoHotkey installation. `tools` is excluded.
 
-Documentation for users is included with AutoHotkey v2, under [Using the Program](https://lexikos.github.io/v2/docs/Program.htm).
-  - [Installation](https://lexikos.github.io/v2/docs/Program.htm#install)
-  - [Launcher](https://lexikos.github.io/v2/docs/Program.htm#launcher)
-  - [Dash](https://lexikos.github.io/v2/docs/Program.htm#dash)
-  - [New Script](https://lexikos.github.io/v2/docs/Program.htm#newscript)
+Documentation for users is included with AutoHotkey v2, under [Using the Program](https://www.autohotkey.com/docs/v2/Program.htm).
+  - [Installation](https://www.autohotkey.com/docs/v2/Program.htm#install)
+  - [Launcher](https://www.autohotkey.com/docs/v2/Program.htm#launcher)
+  - [Dash](https://www.autohotkey.com/docs/v2/Program.htm#dash)
+  - [New Script](https://www.autohotkey.com/docs/v2/Program.htm#newscript)
 
 See the comments at the top of each `.ahk` file for a brief description. Files in the root directory are generally capable of being executed on their own, but may also be used by the dash. Files beginning with "ui-" will show a GUI, whereas other files might have some immediate action and might not show any visible UI.
 


### PR DESCRIPTION
The old links redirect to the same page, however the anchor gets lost. This commit fixes this by specifying the correct links directly.