### PR TITLE
Window Spy: Custom icon is not displayed & control size values are swapped

### DIFF
--- a/WindowSpy.ahk
+++ b/WindowSpy.ahk
@@ -136,8 +136,8 @@ TryUpdate() {
     
     if (curCtrl) {
         ctrlTxt := ControlGetText(curCtrl)
-        WinGetClientPos(&sX, &sY, &sW, &sH, curCtrl)
-        ControlGetPos &cX, &cY, &cW, &cH, curCtrl
+        WinGetClientPos(&sX, &sY, &cW, &cH, curCtrl)
+        ControlGetPos &cX, &cY, &sW, &sH, curCtrl
         
         cText := "ClassNN:`t" curCtrlClassNN "`n"
                . "Text:`t" textMangle(ctrlTxt) "`n"

--- a/WindowSpy.ahk
+++ b/WindowSpy.ahk
@@ -17,6 +17,7 @@ WinSpyGui() {
     Global oGui
     
     try TraySetIcon "inc\spy.ico"
+    try TraySetIcon "UX\inc\spy.ico" ; for CreateWindowSpyRedirect
     DllCall("shell32\SetCurrentProcessExplicitAppUserModelID", "wstr", "AutoHotkey.WindowSpy")
     
     oGui := Gui("AlwaysOnTop Resize MinSize +DPIScale","Window Spy for AHKv2")


### PR DESCRIPTION
This fixes two issues:
- Window Spy has the default icon in the title bar when launched from the tray icon.
- The size values of the control and its client area are swapped.

Forum bug report: https://www.autohotkey.com/boards/viewtopic.php?f=14&t=140242